### PR TITLE
Enable LFS support in post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          lfs: true
       - name: Configure Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Configure the GitHub Actions workflow to use Git LFS during the checkout step.
This is just like in ci.yml